### PR TITLE
Feat/ping devices from dashboard `v1.2.0`

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -17,6 +17,10 @@ class AppConstants {
   static const add = Icon(Icons.add);
   static const sort = Icon(Icons.sort);
 
+  // Home Ping Timeouts and Intervals for scanning
+  static const homePingTimeout = 1;
+  static const homePingInterval = 12;
+
   // Wake Up Dialog Elements
   static const errorMessageColor = Colors.red;
   static const successMessageColor = Colors.green;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -21,6 +21,8 @@
   "homeDeviceListTitle": "Devices",
   "homeDeviceCardWakeButton": "Wake Up",
   "homeDeviceCardEditButton": "Edit",
+  "homeDeviceCardOnline": "Device is online",
+  "homeDeviceCardOffline": "Device is offline",
   "homeWolCardTitle": "Waking up...",
   "@DISCOVER": {},
   "discoverTitle": "Discover Devices",

--- a/lib/screens/home/discover.dart
+++ b/lib/screens/home/discover.dart
@@ -10,9 +10,11 @@ import '../../widgets/layout_elements.dart';
 import '../../widgets/universal_ui_components.dart';
 
 class DiscoverPage extends StatefulWidget {
-  final Function(List<StorageDevice>) updateDevicesList;
+  final Function(List<StorageDevice>, String?) updateDevicesList;
+  final List<StorageDevice> devices;
 
-  const DiscoverPage({Key? key, required this.updateDevicesList})
+  const DiscoverPage(
+      {Key? key, required this.updateDevicesList, required this.devices})
       : super(key: key);
 
   @override
@@ -105,6 +107,7 @@ class _DiscoverPageState extends State<DiscoverPage> {
                   title:
                       AppLocalizations.of(context)!.discoverAddDeviceAlertTitle,
                   device: NetworkDevice(),
+                  devices: widget.devices,
                   onSubmitDeviceCallback: widget.updateDevicesList)),
           text: AppLocalizations.of(context)!.discoverAddCustomDeviceButton,
           icon: const Icon(Icons.add)),
@@ -167,6 +170,7 @@ class _DiscoverPageState extends State<DiscoverPage> {
                                             .discoverAddDeviceAlertTitle,
                                         device: _devices[index]
                                             .copyWith(wolPort: 9),
+                                        devices: widget.devices,
                                         onSubmitDeviceCallback:
                                             widget.updateDevicesList)),
                               );
@@ -221,6 +225,7 @@ class _DiscoverPageState extends State<DiscoverPage> {
       builder: (context) => NetworkDeviceFormPage(
           title: title,
           device: device.copyWith(wolPort: port),
+          devices: widget.devices,
           onSubmitDeviceCallback: widget.updateDevicesList),
     );
   }

--- a/lib/services/data.dart
+++ b/lib/services/data.dart
@@ -30,6 +30,7 @@ abstract class Device implements Comparable<NetworkDevice> {
 class StorageDevice extends Device {
   final String id;
   final DateTime modified;
+  bool? isOnline;
 
   StorageDevice(
       {required this.id,
@@ -37,6 +38,7 @@ class StorageDevice extends Device {
       required ipAddress,
       required macAddress,
       wolPort,
+      this.isOnline,
       required this.modified,
       deviceType})
       : super(
@@ -60,6 +62,7 @@ class StorageDevice extends Device {
     int? wolPort,
     DateTime? modified,
     String? deviceType,
+    bool? isOnline,
   }) {
     return StorageDevice(
       id: id ?? this.id,
@@ -69,6 +72,7 @@ class StorageDevice extends Device {
       wolPort: wolPort ?? this.wolPort,
       modified: modified ?? this.modified,
       deviceType: deviceType ?? this.deviceType,
+      isOnline: isOnline ?? this.isOnline,
     );
   }
 

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -39,19 +39,20 @@ class DeviceStorage {
 
   /// Adds a new device to the list of devices
   /// [device] the device to add
-  Future<List<StorageDevice>> addDevice(NetworkDevice device) async {
-    final devices = await loadDevices();
+  Future<(List<StorageDevice>, StorageDevice)> addDevice(
+      NetworkDevice device, List<StorageDevice> devices) async {
     final storageDevice =
         device.toStorageDevice(id: const Uuid().v1(), modified: DateTime.now());
     final updatedDevices = [...devices, storageDevice];
     await saveDevices(updatedDevices);
-    return updatedDevices;
+    return (updatedDevices, storageDevice);
   }
 
   /// Updates a device in the list of devices
   /// [updatedDevice] the device to update
-  Future<List<StorageDevice>> updateDevice(StorageDevice updatedDevice) async {
-    final devices = await loadDevices();
+  /// [devices] the list of all devices
+  Future<(List<StorageDevice>, StorageDevice)> updateDevice(
+      StorageDevice updatedDevice, List<StorageDevice> devices) async {
     final updatedDevices = devices.map((device) {
       if (device.id == updatedDevice.id) {
         return updatedDevice.copyWith(modified: DateTime.now());
@@ -59,13 +60,13 @@ class DeviceStorage {
       return device;
     }).toList();
     await saveDevices(updatedDevices);
-    return updatedDevices;
+    return (updatedDevices, updatedDevice);
   }
 
   /// Deletes a device from the list of devices
   /// [deviceId] the id of the device to delete
-  Future<List<StorageDevice>> deleteDevice(String deviceId) async {
-    final devices = await loadDevices();
+  Future<List<StorageDevice>> deleteDevice(
+      String deviceId, List<StorageDevice> devices) async {
     final updatedDevices =
         devices.where((device) => device.id != deviceId).toList();
     await saveDevices(updatedDevices);

--- a/lib/services/network.dart
+++ b/lib/services/network.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dart_ping/dart_ping.dart';
+import 'package:simple_wake_on_lan/constants.dart';
 import 'dart:io';
 import 'package:wake_on_lan/wake_on_lan.dart';
 import 'data.dart';
@@ -17,7 +18,7 @@ Stream<NetworkDevice> findDevicesInNetwork(
     step ips away from the current as long as this ip is still within the subnet */
   void pingDevice(int index) async {
     final address = '$networkPrefix.$index';
-    final ping = Ping(address, count: 1, timeout: 1);
+    final ping = Ping(address, count: 1, timeout: AppConstants.homePingTimeout);
 
     // Wait for the current ping to complete
     await for (final response in ping.stream) {
@@ -155,6 +156,19 @@ Stream<List<Message>> sendWolAndGetMessages(
     messages.add(message);
     yield messages;
   }
+}
+
+/// ping a list of devices and return their status
+Future<bool> pingDevice({required String ipAddress}) async {
+  final ping = Ping(ipAddress, count: 1, timeout: 3);
+
+  // Wait for the current ping to complete
+  await for (final response in ping.stream) {
+    if (response.response != null && response.error == null) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /// Playground: Test different Discover methods

--- a/lib/widgets/layout_elements.dart
+++ b/lib/widgets/layout_elements.dart
@@ -144,6 +144,7 @@ class DeviceCard extends StatelessWidget {
   final VoidCallback? onTap;
   final String? title, subtitle, deviceType;
   final Widget? trailing;
+  final bool? isOnline;
 
   const DeviceCard(
       {super.key,
@@ -151,7 +152,8 @@ class DeviceCard extends StatelessWidget {
       this.title,
       this.subtitle,
       this.deviceType,
-      this.trailing});
+      this.trailing,
+      this.isOnline});
 
   @override
   Widget build(BuildContext context) {
@@ -170,8 +172,26 @@ class DeviceCard extends StatelessWidget {
             leading: deviceType != null && getIcon(deviceType!) != null
                 ? SizedBox(
                     height: double.infinity,
-                    child: Icon(
-                      getIcon(deviceType!),
+                    child: Stack(
+                      clipBehavior: Clip.none,
+                      alignment: Alignment.center,
+                      children: [
+                        Icon(
+                          getIcon(deviceType!),
+                        ),
+                        Positioned(
+                          // draw a red marble
+                          top: 12.0,
+                          right: -4.0,
+                          child: Icon(Icons.brightness_1,
+                              size: 12.0,
+                              color: isOnline == null
+                                  ? Colors.grey
+                                  : isOnline!
+                                      ? AppConstants.successMessageColor
+                                      : AppConstants.errorMessageColor),
+                        )
+                      ],
                     ))
                 : null,
             trailing: trailing,

--- a/lib/widgets/universal_ui_components.dart
+++ b/lib/widgets/universal_ui_components.dart
@@ -30,7 +30,7 @@ Widget customDualChoiceAlertdialog(
     IconData? rightIcon,
     Function()? leftOnPressed,
     Function()? rightOnPressed}) {
-  return customAlertdialog(
+  return customAlertDialog(
     title: title,
     child: child,
     icon: icon,
@@ -72,7 +72,7 @@ Widget customDualChoiceAlertdialog(
   );
 }
 
-Widget customAlertdialog(
+Widget customAlertDialog(
     {String? title,
     Widget? child,
     IconData? icon,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,10 +16,10 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+27
+version: 1.2.0+28
 
 environment:
-  sdk: '>=2.19.2 <3.0.0'
+  sdk: '>=3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Closes #1 

- online state of all devices is shown on the home page. The devices get pinged periodically in the background but a user can also swipe down to refresh manually
- Default values for the `2s` timeout  and the `12s` ping interval are hardcoded in `lib/constants.dart` for now.
- dart SDK is upgraded to `v3.0.0` to allow for new language features (e.g. Records)
- interacting with `lib/services/database.dart` was reworked. When an action (`delete`, `add` or `change` a device) is made the devices aren't loaded from disk every time first but are loaded from ram and directly written to disk

